### PR TITLE
Application Launcher

### DIFF
--- a/users/clover/emacs-config.org
+++ b/users/clover/emacs-config.org
@@ -152,3 +152,58 @@ the diff window as well, those buffers open in a seperate window.
     :custom (magit-display-buffer-function #'magit-display-buffer-same-window-except-diff-v1)
     :bind ("C-c g" . magit-status))
 #+end_src
+* Search
+** Counsel
+#+begin_src emacs-lisp
+  (use-package counsel
+    :defer t
+    :config
+    (when
+	(fboundp 'emacs-run-launcher-directories)
+      (emacs-run-launcher-directories)))
+#+end_src
+* System
+This area is for system utilities and system functions such as the app
+launcher for the desktop environment.
+** App Launcher
+Counsel-linux app configuration to improve formatting
+#+begin_src emacs-lisp
+  (defun emacs-run-launcher-format-function
+      (name comment exec)
+    "Formatter for the app launcher. NAME is the name of the application,
+  COMMENT is the applications comment and EXEC is the command to launch"
+    (format "% -25s %s"
+	    (propertize name 'face 'font-lock-buitlin-face)
+	    (or comment "")))
+  (setq counsel-linux-app-format-function #'emacs-run-launcher-format-function)
+#+end_src
+App launcher using counsel-linux-app
+
+Filter app launcher directories to allow overriding of desktop files.
+#+begin_src emacs-lisp
+  (defun emacs-run-launcher-directories ()
+    "Update the directories used by counsel-linux-app"
+    (setq counsel-linux-apps-directories
+	  (seq-remove
+	   (lambda
+	     (x)
+	     (string-prefix-p "/nix/store/" x))
+	   counsel-linux-apps-directories)))
+  ;;(setq counsel-linux-apps-directories '("/home/clover/.nix-profile/share/applications"))
+#+end_src
+Run launcher in own frame with title set to be picked up by window manager.
+#+begin_src emacs-lisp
+  (defun emacs-run-launcher
+      ()
+    "Create and select a frame called emacs-run-launcher which consists only of a minibuffer and has specific dimensions. Run counsel-linux-app on that frame, which is an emacs command that prompts you to select an app and open it in a dmenu like behaviour. Delete the frame after that command has exited"
+    (interactive)
+    (with-selected-frame
+	(make-frame
+	 '((name . "emacs-run-launcher")
+	   (minibuffer . only)
+	   (width . 120)
+	   (height . 11)))
+      (unwind-protect
+	  (counsel-linux-app)
+	(delete-frame))))
+#+end_src

--- a/users/clover/emacs.nix
+++ b/users/clover/emacs.nix
@@ -6,6 +6,7 @@
     package = pkgs.emacs29-pgtk;
     extraPackages = epkgs: with epkgs; [
       all-the-icons
+      counsel
       doom-themes
       fira-code-mode
       hydra
@@ -24,7 +25,14 @@
 
   xdg.configFile."emacs/emacs-config.org".source = ./emacs-config.org;
 
+  # Hide emacs from application menu
+  xdg.desktopEntries.emacs = {
+    name = "Emacs";
+    noDisplay = true;
+  };
+
   home.packages = with pkgs; [
+    gtk3
     emacs-all-the-icons-fonts
   ];
 }

--- a/users/clover/hyprland.nix
+++ b/users/clover/hyprland.nix
@@ -56,7 +56,7 @@
 
     windowrulev2 = [
       "float,title:(emacs-run-launcher)"
-      "size 300, 600,title:(emacs-run-launcher)"
+      "size 600 300,title:(emacs-run-launcher)"
       "center,title:(emacs-run-launcher)"
     ];
 
@@ -72,13 +72,15 @@
     "$mainMod" = "SUPER";
 
     bind = [
-      "$mainMod, Q, exec, kitty"
+      "$mainMod, A, exec, emacsclient -e -r '(emacs-run-launcher)'"
       "$mainMod, C, killactive,"
-      "$mainMod, M, exit,"
-      "$mainMod, V, togglefloating,"
-      "$mainMod, R, exec, wofi --show drun"
-      "$mainMod, P, pseudo,"
+      "$mainMod, E, exec, emacsclient -c"
+      "$mainMod, F, exec, firefox"
       "$mainMod, J, togglesplit,"
+      "$mainMod, M, exit,"
+      "$mainMod, P, pseudo,"
+      "$mainMod, Q, exec, kitty"
+      "$mainMod, V, togglefloating,"
 
       # Move focus with mainMod + arrow keys
       "$mainMod, left, movefocus, l"
@@ -109,10 +111,6 @@
       "$mainMod SHIFT, 8, movetoworkspace, 8"
       "$mainMod SHIFT, 9, movetoworkspace, 9"
       "$mainMod SHIFT, 0, movetoworkspace, 10"
-
-      # Programs
-      "$mainMod, F, exec, firefox"
-      "$mainMod, E, exec, emacsclient -c"
 
       # Volume Mute
       ", XF86AudioMute, exec, wpctl set-mute @DEFAULT_AUDIO_SINK@ toggle"

--- a/users/clover/hyprland.nix
+++ b/users/clover/hyprland.nix
@@ -54,6 +54,12 @@
       ];
     };
 
+    windowrulev2 = [
+      "float,title:(emacs-run-launcher)"
+      "size 300, 600,title:(emacs-run-launcher)"
+      "center,title:(emacs-run-launcher)"
+    ];
+
     dwindle = {
       pseudotile = "yes";
       preserve_split = "yes";


### PR DESCRIPTION
Application launcher using emacs and counsel. Set to open center screen and can hide unwanted desktop entries from showing by overriding in home-manager config.

Closes #7 